### PR TITLE
Fixed typo in EN translation file

### DIFF
--- a/Resources/json/localization/en.json
+++ b/Resources/json/localization/en.json
@@ -23,5 +23,5 @@
     "settings_title": "Settings",
     "revive_text_1": "Continue your game for $value\n",
     "revive_text_2": "You have $value",
-    "credits_text": "Credits \n\nLittle Ninja Boy\n(c) 2019 funkyzooink\n\nCode, Graphic, Sound: Gabriel Heilig\nRessources: OpenGameArt, freesound\nSpecial Thanks to : Kenny\n\n\nThank you for playing!"
+    "credits_text": "Credits \n\nLittle Ninja Boy\n(c) 2019 funkyzooink\n\nCode, Graphic, Sound: Gabriel Heilig\nResources: OpenGameArt, freesound\nSpecial Thanks to : Kenny\n\n\nThank you for playing!"
 }


### PR DESCRIPTION
There was a typo in EN localization file. Should be 'Resources' instead of 'Ressources'